### PR TITLE
final update for daily workload breakdown #64

### DIFF
--- a/Web/src/components/DailyWorkload.tsx
+++ b/Web/src/components/DailyWorkload.tsx
@@ -2,18 +2,26 @@ import React, { useMemo } from "react";
 import { Loader } from "lucide-react";
 import { useAppointmentsForDoctor } from "../hooks/useAppointments";
 import useTreatments from "../hooks/useTreatments";
+import { DateTime } from "luxon";
 
 interface DailyWorkloadProps {
   doctorId: string;
 }
 
 const DailyWorkload: React.FC<DailyWorkloadProps> = ({ doctorId }) => {
-  const today = new Date().toISOString().split("T")[0];
+  const { startOfDay, endOfDay } = useMemo(
+    () => ({
+      startOfDay: DateTime.now().startOf("day").toISO() ?? "",
+      endOfDay: DateTime.now().endOf("day").toISO() ?? "",
+    }),
+    [],
+  );
 
   const { data: appointments, isLoading: isLoadingAppts } =
     useAppointmentsForDoctor({
       doctor_id: doctorId,
-      start_time: today,
+      start_time: startOfDay,
+      end_time: endOfDay,
     });
 
   const { data: treatments, isLoading: isLoadingTreats } = useTreatments({});

--- a/Web/src/components/DailyWorkload.tsx
+++ b/Web/src/components/DailyWorkload.tsx
@@ -1,0 +1,83 @@
+import React, { useMemo } from "react";
+import { useAppointmentsForDoctor } from "../hooks/useAppointments";
+import useTreatments from "../hooks/useTreatments";
+
+interface DailyWorkloadProps {
+  doctorId: string;
+}
+
+const DailyWorkload: React.FC<DailyWorkloadProps> = ({ doctorId }) => {
+  const today = new Date().toISOString().split("T")[0];
+
+  const { data: appointments, isLoading: isLoadingAppts } =
+    useAppointmentsForDoctor({
+      doctor_id: doctorId,
+      start_time: today,
+    });
+
+  const { data: treatments, isLoading: isLoadingTreats } = useTreatments(
+    undefined,
+    true,
+  );
+
+  const workloadData = useMemo(() => {
+    if (!appointments || !treatments) return [];
+
+    const treatmentMap = new Map(
+      treatments.map((t) => [t.id, t.treatment_name]),
+    );
+
+    const counts: Record<string, number> = {};
+
+    appointments.forEach((appt) => {
+      const name =
+        treatmentMap.get(appt.treatment_id || "") || "General Treatment";
+      counts[name] = (counts[name] || 0) + 1;
+    });
+
+    return Object.entries(counts).map(([name, count]) => ({ name, count }));
+  }, [appointments, treatments]);
+
+  if (isLoadingAppts || isLoadingTreats) {
+    return <div className="p-4 text-gray-500 font-medium">Loading data...</div>;
+  }
+
+  return (
+    <div className="bg-white p-6 rounded-xl shadow-sm border border-gray-100 h-full">
+      <div className="border-b pb-3 mb-4">
+        <h3 className="text-lg font-bold text-gray-800">
+          Daily Workload Breakdown
+        </h3>
+        <p className="text-sm text-gray-500 italic">Today's metrics</p>
+      </div>
+
+      <div className="space-y-4">
+        {workloadData.length > 0 ? (
+          workloadData.map((item, index) => (
+            <div
+              key={index}
+              className="flex justify-between items-center group"
+            >
+              <span className="text-gray-600 font-medium group-hover:text-blue-600 transition-colors">
+                {item.name}
+              </span>
+              <div className="flex items-center gap-2">
+                <span className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-bold border border-blue-100">
+                  {item.count} {item.count === 1 ? "Appt" : "Appts"}
+                </span>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="text-center py-6">
+            <p className="text-gray-400 text-sm italic">
+              No appointments scheduled for today
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DailyWorkload;

--- a/Web/src/components/DailyWorkload.tsx
+++ b/Web/src/components/DailyWorkload.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from "react";
+import { Loader } from "lucide-react";
 import { useAppointmentsForDoctor } from "../hooks/useAppointments";
 import useTreatments from "../hooks/useTreatments";
 
@@ -15,10 +16,7 @@ const DailyWorkload: React.FC<DailyWorkloadProps> = ({ doctorId }) => {
       start_time: today,
     });
 
-  const { data: treatments, isLoading: isLoadingTreats } = useTreatments(
-    undefined,
-    true,
-  );
+  const { data: treatments, isLoading: isLoadingTreats } = useTreatments({});
 
   const workloadData = useMemo(() => {
     if (!appointments || !treatments) return [];
@@ -39,43 +37,25 @@ const DailyWorkload: React.FC<DailyWorkloadProps> = ({ doctorId }) => {
   }, [appointments, treatments]);
 
   if (isLoadingAppts || isLoadingTreats) {
-    return <div className="p-4 text-gray-500 font-medium">Loading data...</div>;
+    return (
+      <div className="flex justify-center items-center h-12">
+        <Loader className="animate-spin text-indigo-500" size={24} />
+      </div>
+    );
   }
 
   return (
-    <div className="bg-white p-6 rounded-xl shadow-sm border border-gray-100 h-full">
-      <div className="border-b pb-3 mb-4">
-        <h3 className="text-lg font-bold text-gray-800">
-          Daily Workload Breakdown
-        </h3>
-        <p className="text-sm text-gray-500 italic">Today's metrics</p>
-      </div>
-
-      <div className="space-y-4">
-        {workloadData.length > 0 ? (
-          workloadData.map((item, index) => (
-            <div
-              key={index}
-              className="flex justify-between items-center group"
-            >
-              <span className="text-gray-600 font-medium group-hover:text-blue-600 transition-colors">
-                {item.name}
-              </span>
-              <div className="flex items-center gap-2">
-                <span className="bg-blue-50 text-blue-600 px-3 py-1 rounded-full text-xs font-bold border border-blue-100">
-                  {item.count} {item.count === 1 ? "Appt" : "Appts"}
-                </span>
-              </div>
-            </div>
-          ))
-        ) : (
-          <div className="text-center py-6">
-            <p className="text-gray-400 text-sm italic">
-              No appointments scheduled for today
-            </p>
+    <div className="flex flex-wrap items-center gap-4 text-sm text-slate-600">
+      {workloadData.length > 0 ? (
+        workloadData.map((item, index) => (
+          <div key={index} className="flex items-center gap-1.5 font-medium">
+            <span>{item.name}:</span>
+            <span className="text-indigo-600 font-bold">{item.count}</span>
           </div>
-        )}
-      </div>
+        ))
+      ) : (
+        <span className="text-slate-400 italic">No appointments today</span>
+      )}
     </div>
   );
 };

--- a/Web/src/pages/DashBoard.tsx
+++ b/Web/src/pages/DashBoard.tsx
@@ -1,16 +1,17 @@
 import React, { useMemo } from "react";
 import { Loader } from "lucide-react";
 import { DateTime } from "luxon";
-//components
+// Components
 import Card from "../components/Card";
 import Appointments from "../components/Appointments";
 import LiveClock from "../components/LiveClock";
-//types
+import DailyWorkload from "../components/DailyWorkload";
+// Types
 import { ClinicRoleEnum, type ClinicRole } from "../types/auth";
-//hooks
+// Hooks
 import useDoctors from "../hooks/useDoctors";
 
-// Define a local interface for the user metadata if not already global
+// Define a local interface for the user metadata
 interface UserData {
   id: string;
   user_metadata: {
@@ -28,7 +29,7 @@ const DashBoard: React.FC = () => {
     [],
   );
 
-  // Safely parse user data
+  // Safely parse user data from localStorage
   const userData: UserData | null = useMemo(() => {
     const raw = localStorage.getItem("user");
     if (!raw) return null;
@@ -43,6 +44,7 @@ const DashBoard: React.FC = () => {
   const isDoctor = userData?.user_metadata.role === ClinicRoleEnum.doctor;
   const userId = isDoctor ? userData?.id : undefined;
 
+  // Fetch doctor details based on user ID
   const { data: doctorsData, isLoading } = useDoctors({
     user_id: userId || "",
   });
@@ -50,13 +52,13 @@ const DashBoard: React.FC = () => {
   return (
     <div className="p-6 bg-gray-50 min-h-screen font-sans">
       <Card className="max-w-7xl mx-auto border-none shadow-sm overflow-hidden bg-white">
-        {/* 1. Added a Header section for the clock */}
+        {/* Header section with Live Clock */}
         <div className="px-6 py-4 border-b border-gray-100 flex justify-between items-center bg-white">
-          {/* The clock is isolated here */}
           <div className="bg-indigo-50 px-4 py-2 rounded-xl">
             <LiveClock />
           </div>
         </div>
+
         <div className="p-6">
           {isLoading ? (
             <div className="flex flex-col justify-center items-center h-64 gap-4">
@@ -66,12 +68,22 @@ const DashBoard: React.FC = () => {
               </span>
             </div>
           ) : (
-            <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
-              <Appointments
-                start_time={startOfDay}
-                end_time={endOfDay}
-                doctor_id={doctorsData?.[0]?.id}
-              />
+            <div className="animate-in fade-in slide-in-from-bottom-2 duration-500 space-y-8">
+              {/* Mission #64: Daily Workload Analytics Section */}
+              {isDoctor && doctorsData?.[0]?.id && (
+                <div className="max-w-md">
+                  <DailyWorkload doctorId={doctorsData[0].id} />
+                </div>
+              )}
+
+              {/* Main Appointments Table Section */}
+              <div className="border-t pt-6">
+                <Appointments
+                  start_time={startOfDay}
+                  end_time={endOfDay}
+                  doctor_id={doctorsData?.[0]?.id}
+                />
+              </div>
             </div>
           )}
         </div>

--- a/Web/src/pages/DashBoard.tsx
+++ b/Web/src/pages/DashBoard.tsx
@@ -69,7 +69,7 @@ const DashBoard: React.FC = () => {
             </div>
           ) : (
             <div className="animate-in fade-in slide-in-from-bottom-2 duration-500 space-y-8">
-              {/* Mission #64: Daily Workload Analytics Section */}
+              {/* Daily Workload Analytics Section */}
               {isDoctor && doctorsData?.[0]?.id && (
                 <div className="max-w-md">
                   <DailyWorkload doctorId={doctorsData[0].id} />


### PR DESCRIPTION
Description
This PR introduces a new analytics component for the doctor's dashboard. It provides a visual breakdown of the daily workload by counting and displaying different types of treatments scheduled for the current day. This helps doctors quickly understand their daily schedule at a glance.

Related Issue
Closes #64

Type of Change
[x] New feature

[ ] Bug fix

[ ] Refactor

[ ] Documentation

[ ] Other (please describe):

Changes Made
Created DailyWorkload.tsx component to aggregate and display treatment statistics.

Integrated DailyWorkload into the main DashBoard.tsx page.

Implemented data matching between appointments and treatment names using existing hooks.

Added conditional rendering to ensure the component is only visible to users with the 'doctor' role.

How to Test
Steps to verify this works:

Log in as a user with the Doctor role.

Navigate to the main Dashboard.

Verify that the "Daily Workload Breakdown" card appears above the appointments table.

Ensure the counts match the number of appointments for each treatment type shown in the table below.

<img width="1490" height="747" alt="Screenshot 2026-03-23 at 18 08 17" src="https://github.com/user-attachments/assets/0f4791bd-b5c1-4173-b3d4-a973e0b1dc90" />


Checklist
[x] Code builds and runs locally

[x] No breaking changes (or clearly documented)

[x] Issue is linked (Closes #64)