### PR TITLE
feat: add patient dashboard with filtered appointments and patient na…

### DIFF
--- a/Web/src/components/NavBar.tsx
+++ b/Web/src/components/NavBar.tsx
@@ -12,10 +12,7 @@ import {
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useLocation } from "react-router-dom";
-// Store
 import { useAuthStore } from "../store/authStore";
-
-// Components
 import ProfileButton from "./ProfileButton";
 import DoctorProfileModal from "./modals/profile/DoctorProfileModal";
 import PatientProfileModal from "./modals/profile/PatientProfileModal";
@@ -38,7 +35,6 @@ const NavBar = () => {
   const isDoctorOrAdmin = userRole === "doctor" || userRole === "admin";
   const isPatient = userRole === "patient";
 
-  // Navigation Items
   const navItems = useMemo(
     () => [
       { name: "Home", icon: <Home size={18} />, path: "/" },
@@ -47,16 +43,9 @@ const NavBar = () => {
         icon: <Calendar size={18} />,
         path: "/appointments",
       },
-
       { name: "Patients", icon: <Users size={18} />, path: "/patients" },
-
       { name: "Treatments", icon: <Activity size={18} />, path: "/treatments" },
-
-      {
-        name: "Documents",
-        icon: <FileText size={18} />,
-        path: "/documents",
-      },
+      { name: "Documents", icon: <FileText size={18} />, path: "/documents" },
     ],
     [],
   );
@@ -90,41 +79,41 @@ const NavBar = () => {
           </div>
 
           {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center gap-2">
-            {navItems.map((item) => {
-              const isActive = location.pathname === item.path;
-              return (
-                <button
-                  key={item.name}
-                  onClick={() => navigate(item.path)}
-                  className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 border border-transparent
-                    ${
-                      isActive
-                        ? "bg-white/10 text-cyan-300 border-white/10 shadow-[0_0_15px_rgba(34,211,238,0.15)] backdrop-blur-sm transform scale-105"
-                        : "text-indigo-300 hover:text-white hover:bg-white/5"
-                    }`}
-                >
-                  {item.icon}
-                  <span>{item.name}</span>
-                </button>
-              );
-            })}
-          </div>
+          {isPatient ? (
+            <div className="hidden md:flex flex-col items-center">
+              <span className="text-xs text-indigo-300 uppercase tracking-widest">
+                Welcome back
+              </span>
+              <span className="text-white font-semibold">
+                {user?.user_metadata?.name} {user?.user_metadata?.last_name}
+              </span>
+            </div>
+          ) : (
+            <div className="hidden md:flex items-center gap-2">
+              {navItems.map((item) => {
+                const isActive = location.pathname === item.path;
+                return (
+                  <button
+                    key={item.name}
+                    onClick={() => navigate(item.path)}
+                    className={`flex items-center gap-2 px-4 py-2 rounded-full text-sm font-medium transition-all duration-300 border border-transparent
+                      ${
+                        isActive
+                          ? "bg-white/10 text-cyan-300 border-white/10 shadow-[0_0_15px_rgba(34,211,238,0.15)] backdrop-blur-sm transform scale-105"
+                          : "text-indigo-300 hover:text-white hover:bg-white/5"
+                      }`}
+                  >
+                    {item.icon}
+                    <span>{item.name}</span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
 
           {/* Right Side Actions */}
           <div className="flex items-center gap-4">
-            <div className="hidden sm:flex items-center gap-3">
-              <button
-                onClick={handleLogout}
-                className="flex items-center gap-2 px-4 py-2 text-rose-300 bg-rose-500/10 hover:bg-rose-500/20 rounded-full transition-colors text-xs font-bold border border-rose-500/10"
-              >
-                <LogOut size={14} />
-                <span>Exit</span>
-              </button>
-              <div className="w-px h-6 bg-indigo-800/50" />
-            </div>
-
-            {/* Profile Button Integration */}
+            {/* Profile Button */}
             {isDoctorOrAdmin && (
               <ProfileButton
                 onClick={() => setIsDoctorProfileModalOpen(true)}
@@ -136,13 +125,26 @@ const NavBar = () => {
               />
             )}
 
-            {/* Mobile Menu Toggle */}
-            <button
-              className="md:hidden p-2 text-indigo-200 hover:text-white"
-              onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-            >
-              {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
-            </button>
+            {/* Exit Button */}
+            <div className="hidden sm:flex items-center gap-3">
+              <button
+                onClick={handleLogout}
+                className="flex items-center gap-2 px-4 py-2 text-rose-300 bg-rose-500/10 hover:bg-rose-500/20 rounded-full transition-colors text-xs font-bold border border-rose-500/10"
+              >
+                <LogOut size={14} />
+                <span>Exit</span>
+              </button>
+            </div>
+
+            {/* Mobile Menu Toggle — hidden for patients */}
+            {!isPatient && (
+              <button
+                className="md:hidden p-2 text-indigo-200 hover:text-white"
+                onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+              >
+                {isMobileMenuOpen ? <X size={24} /> : <Menu size={24} />}
+              </button>
+            )}
           </div>
         </nav>
       </header>
@@ -181,7 +183,7 @@ const NavBar = () => {
         </div>
       )}
 
-      {/* Modal Component */}
+      {/* Modals */}
       {isDoctorOrAdmin ? (
         <DoctorProfileModal
           isModalOpen={isDoctorProfileModalOpen}

--- a/Web/src/components/NavBar.tsx
+++ b/Web/src/components/NavBar.tsx
@@ -12,7 +12,10 @@ import {
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useLocation } from "react-router-dom";
+// Store
 import { useAuthStore } from "../store/authStore";
+
+// Components
 import ProfileButton from "./ProfileButton";
 import DoctorProfileModal from "./modals/profile/DoctorProfileModal";
 import PatientProfileModal from "./modals/profile/PatientProfileModal";
@@ -35,6 +38,7 @@ const NavBar = () => {
   const isDoctorOrAdmin = userRole === "doctor" || userRole === "admin";
   const isPatient = userRole === "patient";
 
+  // Navigation Items
   const navItems = useMemo(
     () => [
       { name: "Home", icon: <Home size={18} />, path: "/" },
@@ -79,16 +83,7 @@ const NavBar = () => {
           </div>
 
           {/* Desktop Navigation */}
-          {isPatient ? (
-            <div className="hidden md:flex flex-col items-center">
-              <span className="text-xs text-indigo-300 uppercase tracking-widest">
-                Welcome back
-              </span>
-              <span className="text-white font-semibold">
-                {user?.user_metadata?.name} {user?.user_metadata?.last_name}
-              </span>
-            </div>
-          ) : (
+          {!isPatient && (
             <div className="hidden md:flex items-center gap-2">
               {navItems.map((item) => {
                 const isActive = location.pathname === item.path;

--- a/Web/src/pages/DashBoard.tsx
+++ b/Web/src/pages/DashBoard.tsx
@@ -11,6 +11,8 @@ import { ClinicRoleEnum, type UserProfile } from "../types/auth";
 import useDoctors from "../hooks/useDoctors";
 import DailyWorkload from "../components/DailyWorkload";
 
+import PatientDashboard from "./PatientDashboard";
+
 const DashBoard: React.FC = () => {
   // Memoize date calculations to prevent unnecessary re-renders
   const { startOfDay, endOfDay } = useMemo(
@@ -40,9 +42,15 @@ const DashBoard: React.FC = () => {
     userData?.user_metadata.role === ClinicRoleEnum.admin ||
     userData?.user_metadata.role === ClinicRoleEnum.secretary;
 
+  const isPatient = userData?.user_metadata.role === ClinicRoleEnum.patient;
+
   const { data: doctorsData, isLoading } = useDoctors({
     user_id: userId || "",
   });
+
+  if (isPatient) {
+    return <PatientDashboard />;
+  }
 
   return (
     <div className="p-6 bg-gray-50 min-h-screen font-sans">

--- a/Web/src/pages/PatientDashboard.tsx
+++ b/Web/src/pages/PatientDashboard.tsx
@@ -1,0 +1,54 @@
+import React, { useMemo } from "react";
+import { Loader } from "lucide-react";
+import Card from "../components/Card";
+import Appointments from "../components/Appointments";
+import LiveClock from "../components/LiveClock";
+import usePatients from "../hooks/usePatients";
+import type { UserProfile } from "../types/auth";
+
+const PatientDashboard: React.FC = () => {
+  const userData: UserProfile | null = useMemo(() => {
+    const raw = localStorage.getItem("user");
+    if (!raw) return null;
+    try {
+      return JSON.parse(raw);
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const { data: patientsData, isLoading } = usePatients({
+    user_id: userData?.id ?? "",
+  });
+
+  const patientId = patientsData?.[0]?.patient_id;
+
+  return (
+    <div className="p-4 lg:p-6 bg-gray-50 min-h-screen font-sans">
+      <Card className="border-none shadow-sm overflow-hidden bg-white">
+        <div className="px-6 py-4 border-b border-gray-100 flex items-center bg-white">
+          <div className="bg-indigo-50 px-4 py-2 rounded-xl">
+            <LiveClock />
+          </div>
+        </div>
+
+        <div className="p-6">
+          {isLoading ? (
+            <div className="flex flex-col justify-center items-center h-64 gap-4">
+              <Loader className="animate-spin text-indigo-600" size={40} />
+              <span className="text-indigo-600/60 font-medium animate-pulse">
+                Loading your appointments...
+              </span>
+            </div>
+          ) : (
+            <div className="animate-in fade-in slide-in-from-bottom-2 duration-500">
+              <Appointments patient_id={patientId} />
+            </div>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default PatientDashboard;

--- a/Web/src/pages/PatientDashboard.tsx
+++ b/Web/src/pages/PatientDashboard.tsx
@@ -22,14 +22,27 @@ const PatientDashboard: React.FC = () => {
   });
 
   const patientId = patientsData?.[0]?.patient_id;
+  const patientName = patientsData?.[0]
+    ? `${patientsData[0].first_name} ${patientsData[0].last_name}`
+    : "";
 
   return (
     <div className="p-4 lg:p-6 bg-gray-50 min-h-screen font-sans">
       <Card className="border-none shadow-sm overflow-hidden bg-white">
-        <div className="px-6 py-4 border-b border-gray-100 flex items-center bg-white">
+        <div className="px-6 py-4 border-b border-gray-100 relative flex items-center justify-between bg-white">
           <div className="bg-indigo-50 px-4 py-2 rounded-xl">
             <LiveClock />
           </div>
+          {patientName && (
+            <div className="flex flex-col items-center absolute left-1/2 -translate-x-1/2">
+              <span className="text-xs text-indigo-400 uppercase tracking-widest">
+                Welcome back
+              </span>
+              <span className="text-sm font-semibold text-slate-700">
+                {patientName}
+              </span>
+            </div>
+          )}
         </div>
 
         <div className="p-6">


### PR DESCRIPTION
## Description
Added a dedicated dashboard for patients with a clean, role-specific UI.
## Related Issue
Closes #86
## Type of Change
- [x] New feature
## Changes Made
- Created `PatientDashboard.tsx` — shows only LiveClock and appointments filtered by patient_id
- Updated `DashBoard.tsx` — detects patient role and renders PatientDashboard
- Updated `NavBar.tsx` — hides all nav links for patients, shows "Welcome back [name]" in center, Profile + Exit on right
## How to Test
1. Login with a patient account
2. Navigate to /dashboard — should see only your own appointments
3. Verify navbar shows "Welcome back [name]" with no navigation links
4. Login with doctor/admin — verify normal dashboard still works

<img width="1910" height="981" alt="Screenshot 2026-04-16 at 13 05 27" src="https://github.com/user-attachments/assets/21c3443a-5549-49cd-a398-123945ca59b5" />


## Checklist
- [x] Code builds and runs locally
- [x] No breaking changes
- [x] Issue is linked (`Closes #86`)