### PR TITLE
feat: add room selection to appointments and Rooms management page

### DIFF
--- a/Web/src/App.tsx
+++ b/Web/src/App.tsx
@@ -21,6 +21,7 @@ import Chat from "./components/Chat";
 //types
 import { ClinicRoleEnum } from "./types/auth";
 import Documents from "./pages/Documents";
+import Rooms from "./pages/Rooms";
 
 const SERVER_URL = import.meta.env.VITE_API_URL || "http://localhost:3001";
 
@@ -114,6 +115,10 @@ function App() {
           <Route
             path="/documents"
             element={isAuthenticated ? <Documents /> : <Navigate to="/login" />}
+          />
+          <Route
+            path="/rooms"
+            element={isAuthenticated ? <Rooms /> : <Navigate to="/login" />}
           />
         </Routes>
       </main>

--- a/Web/src/api/types/appointments.ts
+++ b/Web/src/api/types/appointments.ts
@@ -35,6 +35,7 @@ export interface Appointment {
   status: AppointmentStatus;
   notes: string;
   created_at: string;
+  room_id?: string | null;
   patients?: {
     first_name: string;
     last_name: string;
@@ -58,6 +59,7 @@ export interface CreateAppointmentDTO {
   notes?: string;
   treatment_id: string;
   treatment_data: Record<string, string | number | boolean | File>;
+  room_id?: string | null;
 }
 
 export interface UpdateAppointmentDTO {

--- a/Web/src/components/Appointments.tsx
+++ b/Web/src/components/Appointments.tsx
@@ -7,6 +7,7 @@ import {
   Clock,
   ClipboardList,
   Stethoscope,
+  DoorOpen,
 } from "lucide-react";
 import { DateTime } from "luxon";
 //components
@@ -16,6 +17,7 @@ import Card from "./Card";
 //hooks
 import useAppointments from "../hooks/useAppointments";
 import useTreatments from "../hooks/useTreatments";
+import useRooms from "../hooks/useRooms";
 import { useIsMobile } from "../hooks/useIsMobile";
 //types
 import {
@@ -41,6 +43,7 @@ const Appointments: React.FC<AppointmentFilters> = (props) => {
     error,
   } = useAppointments(filters);
   const { data: treatments } = useTreatments({});
+  const { data: rooms } = useRooms();
 
   const [showIds, setShowIds] = useState(false);
   const [selectedAppointment, setSelectedAppointment] =
@@ -66,6 +69,12 @@ const Appointments: React.FC<AppointmentFilters> = (props) => {
     (a: Appointment) =>
       treatments?.find((t) => t.id === a.treatment_id)?.treatment_name || "N/A",
     [treatments],
+  );
+
+  const getRoomNumber = useCallback(
+    (a: Appointment) =>
+      rooms?.find((r) => r.id === a.room_id)?.room_number ?? null,
+    [rooms],
   );
 
   const treatmentTemplate = useMemo(
@@ -123,8 +132,22 @@ const Appointments: React.FC<AppointmentFilters> = (props) => {
         ),
       },
       { header: "NOTES", accessor: (a: Appointment) => a.notes || "-" },
+      {
+        header: "ROOM",
+        accessor: (a: Appointment) => {
+          const roomNumber = getRoomNumber(a);
+          return roomNumber ? (
+            <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold bg-indigo-50 text-indigo-700 border border-indigo-200">
+              <DoorOpen size={12} />
+              {roomNumber}
+            </span>
+          ) : (
+            <span className="text-slate-400">—</span>
+          );
+        },
+      },
     ],
-    [showIds, getPatientName, getDoctorName, getTreatmentName],
+    [showIds, getPatientName, getDoctorName, getTreatmentName, getRoomNumber],
   );
 
   if (isLoading)
@@ -160,7 +183,6 @@ const Appointments: React.FC<AppointmentFilters> = (props) => {
         <h2 className="text-2xl font-bold text-slate-800 tracking-tight">
           Appointments
         </h2>
-
         <div className="bg-white px-4 py-2.5 rounded-xl border border-slate-200 shadow-sm text-sm text-slate-600 flex items-center gap-2">
           Total:
           <span className="font-bold text-indigo-600">
@@ -199,12 +221,18 @@ const Appointments: React.FC<AppointmentFilters> = (props) => {
                       {getDoctorName(appointment)}
                     </span>
                   </div>
-
                   <div className="flex items-center gap-2">
                     <ClipboardList size={16} className="text-slate-400" />
                     <span>{getTreatmentName(appointment)}</span>
                   </div>
-
+                  {getRoomNumber(appointment) && (
+                    <div className="flex items-center gap-2">
+                      <DoorOpen size={16} className="text-slate-400" />
+                      <span className="font-medium text-indigo-600">
+                        Room {getRoomNumber(appointment)}
+                      </span>
+                    </div>
+                  )}
                   <div className="flex items-center gap-2">
                     <Clock size={16} className="text-slate-400" />
                     <span className="font-medium text-indigo-600">
@@ -213,13 +241,11 @@ const Appointments: React.FC<AppointmentFilters> = (props) => {
                       )}
                     </span>
                   </div>
-
                   {appointment.notes && (
                     <div className="pt-2 border-t border-slate-100 text-xs italic text-slate-500 line-clamp-2">
                       {appointment.notes}
                     </div>
                   )}
-
                   <div
                     className="flex justify-between items-center pt-2 border-t border-slate-100"
                     onClick={(e) => e.stopPropagation()}

--- a/Web/src/components/NavBar.tsx
+++ b/Web/src/components/NavBar.tsx
@@ -9,6 +9,7 @@ import {
   Menu,
   X,
   FileText,
+  DoorOpen,
 } from "lucide-react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useNavigate, useLocation } from "react-router-dom";
@@ -50,6 +51,7 @@ const NavBar = () => {
       { name: "Patients", icon: <Users size={18} />, path: "/patients" },
       { name: "Treatments", icon: <Activity size={18} />, path: "/treatments" },
       { name: "Documents", icon: <FileText size={18} />, path: "/documents" },
+      { name: "Rooms", icon: <DoorOpen size={18} />, path: "/rooms" },
     ],
     [],
   );

--- a/Web/src/components/modals/CreateAppointmentModal.tsx
+++ b/Web/src/components/modals/CreateAppointmentModal.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import usePatients from "../../hooks/usePatients";
 import useTreatments from "../../hooks/useTreatments";
 import useDoctors from "../../hooks/useDoctors";
+import useRooms from "../../hooks/useRooms";
 //developed
 import CreateAppointmentCalendar from "../CreateAppointmentCalendar";
 //types
@@ -25,6 +26,7 @@ const initFormData = {
   start_time: "",
   end_time: "",
   notes: "",
+  room_id: "",
 };
 
 const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
@@ -47,6 +49,7 @@ const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
     isLoading: doctorsLoading,
     isError: doctorError,
   } = useDoctors({});
+  const { data: rooms } = useRooms({ status: "Active" });
   const [formData, setFormData] = useState(initFormData);
   const [selectedTreatment, setSelectedTreatment] = useState<
     Treatment | undefined
@@ -89,7 +92,7 @@ const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
             case "checkbox":
               treatmentData[field.id] = field.defaultValue ?? false;
               break;
-            default: // text, textarea, select
+            default:
               treatmentData[field.id] = field.defaultValue ?? "";
               break;
           }
@@ -125,6 +128,7 @@ const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
       setFormData(initFormData);
     }
   };
+
   const handleCancel = () => {
     setFormData(initFormData);
     onClose();
@@ -144,6 +148,11 @@ const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
     }
 
     const selectedDoctor = doctors?.find((d) => d.id === formData.doctor_id);
+    const availableRooms = rooms?.filter(
+      (r) =>
+        r.allowed_treatments.length === 0 ||
+        r.allowed_treatments.includes(formData.treatment_id),
+    );
 
     return (
       <form
@@ -230,11 +239,40 @@ const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
             <textarea
               id="notes"
               name="notes"
-              rows={12}
+              rows={6}
               value={formData.notes}
               onChange={handleChange}
               className="block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
             ></textarea>
+          </div>
+          <div className="mb-4">
+            <label
+              htmlFor="room_id"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Room
+            </label>
+            <select
+              id="room_id"
+              name="room_id"
+              value={formData.room_id}
+              onChange={handleChange}
+              disabled={!formData.start_time || !formData.treatment_id}
+              className="block w-full px-3 py-2 bg-white border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <option value="">
+                {!formData.treatment_id
+                  ? "Select a treatment first"
+                  : !formData.start_time
+                    ? "Select a time slot first"
+                    : "No room (optional)"}
+              </option>
+              {availableRooms?.map((r) => (
+                <option key={r.id} value={r.id}>
+                  Room {r.room_number}
+                </option>
+              ))}
+            </select>
           </div>
           <div className="mt-6 flex justify-end">
             <button
@@ -290,6 +328,7 @@ const CreateAppointmentModal: React.FC<CreateAppointmentModalProps> = ({
           <h2 className="text-xl font-bold">New Appointment</h2>
           <button
             onClick={handleCancel}
+            aria-label="Close"
             className="text-gray-400 hover:text-gray-600 transition-colors"
           >
             <X size={20} />

--- a/Web/src/pages/Rooms.tsx
+++ b/Web/src/pages/Rooms.tsx
@@ -1,0 +1,241 @@
+import { useState } from "react";
+import { AlertTriangle, DoorOpen, Loader, Plus, X } from "lucide-react";
+// Store
+import { useAuthStore } from "../store/authStore";
+// Hooks
+import useRooms, { useCreateRoom } from "../hooks/useRooms";
+import useTreatments from "../hooks/useTreatments";
+// Components
+import Card from "../components/Card";
+import Hint from "../components/hint";
+
+const Rooms = () => {
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [roomNumber, setRoomNumber] = useState("");
+  const [selectedTreatments, setSelectedTreatments] = useState<string[]>([]);
+
+  const { data: rooms, isLoading, isError, error } = useRooms();
+  const { data: treatments } = useTreatments({});
+  const { mutate: createRoom, isPending: isCreating } = useCreateRoom();
+
+  const user = useAuthStore((state) => state.user);
+  const userRole = user?.user_metadata?.role;
+  const isDoctorOrAdmin = userRole === "doctor" || userRole === "admin";
+
+  const handleToggleTreatment = (id: string) => {
+    setSelectedTreatments((prev) =>
+      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id],
+    );
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!roomNumber.trim()) return;
+
+    createRoom(
+      {
+        room_number: roomNumber.trim(),
+        status: "Active",
+        allowed_treatments: selectedTreatments,
+      },
+      {
+        onSuccess: () => {
+          setRoomNumber("");
+          setSelectedTreatments([]);
+          setIsFormOpen(false);
+        },
+      },
+    );
+  };
+
+  const getTreatmentName = (id: string) =>
+    treatments?.find((t) => t.id === id)?.treatment_name ?? id;
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center h-64">
+        <Loader className="animate-spin text-indigo-500" size={48} />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col items-center justify-center h-64 bg-red-50 border border-red-200 rounded-lg p-8 m-6">
+        <AlertTriangle className="text-red-500" size={48} />
+        <h2 className="mt-4 text-xl font-semibold text-red-800">
+          Error Fetching Rooms
+        </h2>
+        <p className="mt-2 text-red-600">
+          {error?.message || "Failed to load rooms."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="container mx-auto p-4 sm:p-6 animate-fade-in">
+      <div className="text-center mb-12">
+        <h1 className="text-4xl font-extrabold text-gray-800 tracking-tight">
+          Rooms
+        </h1>
+      </div>
+
+      <div className="flex flex-col sm:flex-row justify-between items-center mb-8 gap-4">
+        <div className="w-full sm:w-auto">
+          <Hint text="View and manage clinic rooms and their allowed treatments." />
+        </div>
+        {isDoctorOrAdmin && (
+          <button
+            onClick={() => setIsFormOpen(true)}
+            className="flex items-center gap-2 px-6 py-3 bg-indigo-600 text-white font-semibold rounded-lg shadow-md hover:bg-indigo-700 transition-all hover:shadow-lg active:scale-95 whitespace-nowrap"
+          >
+            <Plus size={20} />
+            New Room
+          </button>
+        )}
+      </div>
+
+      {/* New Room Modal */}
+      {isFormOpen && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center">
+          <div className="bg-white p-6 rounded-xl shadow-xl w-full max-w-md mx-4">
+            <div className="flex justify-between items-center mb-6">
+              <h2 className="text-xl font-bold text-gray-800">New Room</h2>
+              <button
+                onClick={() => setIsFormOpen(false)}
+                className="text-gray-400 hover:text-gray-600"
+              >
+                <X size={20} />
+              </button>
+            </div>
+
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Room Number
+                </label>
+                <input
+                  type="text"
+                  value={roomNumber}
+                  onChange={(e) => setRoomNumber(e.target.value)}
+                  placeholder="e.g. 1, 2A, 101"
+                  required
+                  className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm"
+                />
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  Allowed Treatments{" "}
+                  <span className="text-gray-400 font-normal">
+                    (leave empty = all treatments)
+                  </span>
+                </label>
+                <div className="max-h-48 overflow-y-auto border border-gray-200 rounded-md p-2 space-y-1">
+                  {treatments?.map((t) => (
+                    <label
+                      key={t.id}
+                      className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-50 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedTreatments.includes(t.id)}
+                        onChange={() => handleToggleTreatment(t.id)}
+                        className="rounded text-indigo-600"
+                      />
+                      <span className="text-sm text-gray-700">
+                        {t.treatment_name}
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className="flex justify-end gap-3 pt-2">
+                <button
+                  type="button"
+                  onClick={() => setIsFormOpen(false)}
+                  className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 hover:bg-gray-200 rounded-md"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={isCreating}
+                  className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-md disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+                >
+                  {isCreating && <Loader className="animate-spin" size={14} />}
+                  {isCreating ? "Creating..." : "Create Room"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Rooms Grid */}
+      {!rooms || rooms.length === 0 ? (
+        <div className="text-center py-20 bg-gray-50 rounded-2xl border-2 border-dashed border-gray-200">
+          <div className="bg-gray-100 w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-4">
+            <DoorOpen className="text-gray-400" size={32} />
+          </div>
+          <h3 className="text-lg font-medium text-gray-900">No rooms found</h3>
+          <p className="text-gray-500 mt-1">Start by creating a new room.</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-6">
+          {rooms.map((room) => (
+            <Card
+              key={room.id}
+              title={
+                <div className="flex justify-between items-center w-full">
+                  <div className="p-3 bg-indigo-50 rounded-lg">
+                    <DoorOpen className="text-indigo-600" size={24} />
+                  </div>
+                  <span
+                    className={`text-xs font-bold px-3 py-1 rounded-full ${
+                      room.status === "Active"
+                        ? "bg-green-50 text-green-700 border border-green-200"
+                        : "bg-gray-100 text-gray-500 border border-gray-200"
+                    }`}
+                  >
+                    {room.status}
+                  </span>
+                </div>
+              }
+            >
+              <h2 className="text-2xl font-extrabold text-gray-800 mb-3">
+                Room {room.room_number}
+              </h2>
+
+              <div className="space-y-1">
+                <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">
+                  Allowed Treatments
+                </p>
+                {room.allowed_treatments.length === 0 ? (
+                  <p className="text-sm text-indigo-600 font-medium">
+                    All treatments
+                  </p>
+                ) : (
+                  <div className="flex flex-wrap gap-1.5 mt-1">
+                    {room.allowed_treatments.map((id) => (
+                      <span
+                        key={id}
+                        className="text-xs px-2 py-0.5 bg-indigo-50 text-indigo-700 rounded-full border border-indigo-100"
+                      >
+                        {getTreatmentName(id)}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Rooms;


### PR DESCRIPTION
## Description
Added room number feature to appointments — users can now assign a clinic room when creating an appointment. Also added a dedicated Rooms management page where admins/doctors can view and create rooms.

## Related Issue
Closes #56

## Type of Change
- [x] New feature

## Changes Made
- Added `room_id` field to `Appointment` and `CreateAppointmentDTO` types
- Added room dropdown to `CreateAppointmentModal` — filtered by `allowed_treatments` and disabled until treatment + time slot are selected
- Added ROOM column to Appointments table (rightmost column)
- Added new Rooms page (`/rooms`) with room cards grid and create room modal
- Added Rooms link and icon to NavBar

## How to Test
1. Go to Appointments → click "New Appointment"
2. Select a treatment and a time slot — the Room dropdown should become active
3. Select a room and create the appointment — verify ROOM column shows the room number in the table
4. Go to Rooms page via NavBar — verify rooms are displayed as cards
5. Click "New Room" (admin/doctor only) → fill in room number and optional treatments → verify new room appears

## Checklist
- [x] Code builds and runs locally
- [x] No breaking changes
- [x] Issue is linked (`Closes #56`)